### PR TITLE
Feature/local repo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Convert GitHub repositories to text files with ease. This CLI tool downloads a r
 ## Features
 
 - 📥 Download any public GitHub repository
+- 🔒 Process local Git repositories (including private ones)
 - 📝 Convert repository contents to a single text file
 - ⚡ Automatic binary file exclusion
 - 🔧 Configurable file size threshold
@@ -31,6 +32,9 @@ git2txt username/repository
 
 # SSH format
 git2txt git@github.com:username/repository
+
+# Local repository path (requires --local flag)
+git2txt /path/to/local/repo --local
 ```
 
 ### URL Format Support
@@ -42,6 +46,7 @@ The tool accepts these GitHub repository URL formats:
 - SSH URLs: `git@github.com:username/repository`
 - URLs with or without `.git` suffix
 - URLs with or without trailing slashes
+- Local paths with `--local` flag: `/path/to/repo` or `./relative/path`
 
 ### Options
 
@@ -49,6 +54,7 @@ The tool accepts these GitHub repository URL formats:
 --output, -o     Specify output file path (default: repo-name.txt)
 --threshold, -t  Set file size threshold in MB (default: 0.1)
 --include-all    Include all files regardless of size or type
+--local         Process local repository path
 --debug         Enable debug mode with verbose logging
 --help          Show help
 --version       Show version
@@ -78,6 +84,15 @@ git2txt username/repository --include-all
 
 # Enable debug output
 git2txt username/repository --debug
+
+# Using local repository path
+git2txt /path/to/local/repo --local
+
+# Local repository with custom output
+git2txt ./my-repo --local --output=output.txt
+
+# Local repository with custom threshold
+git2txt ./my-repo --local --threshold=2
 ```
 
 ## Default Behavior


### PR DESCRIPTION
# Add support for local repositories

## Overview
This PR adds support for processing local Git repositories, allowing users to convert already cloned repositories (including private ones) to text format without requiring GitHub access.

## Key Changes
- Added `--local` flag to specify that the input is a local repository path
- Implemented local repository validation to ensure path points to a valid Git repository
- Modified input validation to support both remote URLs and local paths
- Updated main processing logic to handle local repositories without temporary directory cleanup
- Added documentation for local repository usage
- Updated README.md to document local repository support

## Usage Examples
You can now use git2txt with local repositories:

```bash
# Process a local repository
git2txt /path/to/local/repo --local

# Using relative paths
git2txt ./my-repo --local

# Specify custom output file
git2txt ./my-repo --local --output=analysis.txt

# Include all files regardless of size/type
git2txt ./my-repo --local --include-all
```

## Why?
This enhancement addresses several use cases:
1. Working with private repositories that are already cloned locally
2. Processing repositories without needing GitHub authentication
3. Analyzing repositories with uncommitted changes
4. Improving performance by skipping the download step
5. Working in environments with limited GitHub access

## Testing
The changes have been tested with:
- Different repository sizes
- Various file types
- Relative and absolute paths
- Repositories with uncommitted changes
- Invalid repository paths
- Edge cases (empty repositories, no .git directory)

## Documentation
The help text and README have been updated to include:
- New `--local` flag description
- Usage examples with local repositories
- Updated feature list
- Additional use cases

## Implementation Notes
- Local repository validation checks for both directory existence and `.git` folder presence
- Repository name is extracted from the directory name for output file naming
- Temporary directory cleanup is skipped for local repositories
- All existing functionality for remote repositories remains unchanged

## Future Considerations
Potential future enhancements could include:
- Support for specific Git branches/tags in local repositories
- Custom file inclusion/exclusion patterns
- Diff analysis for uncommitted changes

Let me know if you would like me to clarify or modify any part of these changes.