### PR TITLE
Fix: Improve repository name extraction and add debug logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,28 +95,93 @@ export const cli = meow(helpText, {
  */
 function normalizeGitHubUrl(url) {
     try {
+        const originalUrl = url;
         // Remove trailing slashes
         url = url.replace(/\/+$/, '');
         
         // Handle git@ URLs
         if (url.startsWith('git@github.com:')) {
+            if (cli.flags.debug) {
+                console.log(chalk.blue('Debug: URL format:'), 'SSH');
+                console.log(chalk.blue('Debug: Original URL:'), originalUrl);
+                console.log(chalk.blue('Debug: Normalized URL:'), url);
+            }
             return url;
         }
         
         // Handle full HTTPS URLs
         if (url.startsWith('https://github.com/')) {
+            if (cli.flags.debug) {
+                console.log(chalk.blue('Debug: URL format:'), 'HTTPS');
+                console.log(chalk.blue('Debug: Original URL:'), originalUrl);
+                console.log(chalk.blue('Debug: Normalized URL:'), url);
+            }
             return url;
         }
         
         // Handle short format (user/repo)
         if (url.match(/^[\w-]+\/[\w-]+$/)) {
-            return `https://github.com/${url}`;
+            const normalized = `https://github.com/${url}`;
+            if (cli.flags.debug) {
+                console.log(chalk.blue('Debug: URL format:'), 'Short');
+                console.log(chalk.blue('Debug: Original URL:'), originalUrl);
+                console.log(chalk.blue('Debug: Normalized URL:'), normalized);
+            }
+            return normalized;
         }
         
         throw new Error('Invalid GitHub repository URL format');
     } catch (error) {
         throw new Error(`Invalid GitHub URL: ${url}`);
     }
+}
+
+/**
+ * Extracts repository name from a GitHub URL
+ * @param {string} url - GitHub repository URL
+ * @returns {string} Repository name
+ */
+function extractRepoName(url) {
+    const originalUrl = url;
+    // Remove trailing slashes and .git suffix
+    url = url.replace(/\/+$/, '').replace(/\.git$/, '');
+    
+    let repoName;
+    
+    // Handle git@ URLs
+    if (url.startsWith('git@github.com:')) {
+        repoName = url.split(':')[1].split('/')[1];
+        if (cli.flags.debug) {
+            console.log(chalk.blue('Debug: Extracting from SSH URL'));
+            console.log(chalk.blue('Debug: Original URL:'), originalUrl);
+            console.log(chalk.blue('Debug: Extracted repo name:'), repoName);
+        }
+        return repoName;
+    }
+    
+    // Handle full HTTPS URLs
+    if (url.startsWith('https://github.com/')) {
+        repoName = url.split('/').slice(-1)[0];
+        if (cli.flags.debug) {
+            console.log(chalk.blue('Debug: Extracting from HTTPS URL'));
+            console.log(chalk.blue('Debug: Original URL:'), originalUrl);
+            console.log(chalk.blue('Debug: Extracted repo name:'), repoName);
+        }
+        return repoName;
+    }
+    
+    // Handle short format (user/repo)
+    if (url.match(/^[\w-]+\/[\w-]+$/)) {
+        repoName = url.split('/')[1];
+        if (cli.flags.debug) {
+            console.log(chalk.blue('Debug: Extracting from short format'));
+            console.log(chalk.blue('Debug: Original URL:'), originalUrl);
+            console.log(chalk.blue('Debug: Extracted repo name:'), repoName);
+        }
+        return repoName;
+    }
+    
+    throw new Error('Invalid GitHub repository URL format');
 }
 
 /**
@@ -151,10 +216,11 @@ export async function downloadRepository(url) {
     try {
         // Normalize the GitHub URL
         const normalizedUrl = normalizeGitHubUrl(url);
-        const repoName = url.split('/').pop().replace('.git', '');
+        const repoName = extractRepoName(url);
         
         if (cli.flags.debug) {
             console.log(chalk.blue('Debug: Normalized URL:'), normalizedUrl);
+            console.log(chalk.blue('Debug: Repository name:'), repoName);
             console.log(chalk.blue('Debug: Temp directory:'), tempDir);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git2txt",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "CLI tool to convert GitHub repositories to text files",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixes #13

## Changes
- Added new `extractRepoName` function to handle all GitHub URL formats consistently:
  - HTTPS URLs (e.g., `https://github.com/username/repo`)
  - SSH URLs (e.g., `git@github.com:username/repo`)
  - Short format (e.g., `username/repo`)
- Added debug logging to help users understand URL processing
- Fixed trailing slash and .git suffix handling

## Testing
The fix has been tested with all supported URL formats:

1. HTTPS URL:
```bash
git2txt https://github.com/username/repository
# Creates: repository.txt
```

2. Short format:
```bash
git2txt username/repository
# Creates: repository.txt
```

3. SSH URL:
```bash
git2txt git@github.com:username/